### PR TITLE
Fix operator precedence in mktype (#4)

### DIFF
--- a/cough/symbol.py
+++ b/cough/symbol.py
@@ -65,7 +65,7 @@ class ComplexType(enum.IntEnum):
 
 
 def mktype(base, comp):
-    return comp << 8 + base
+    return (comp << 8) + base
 
 
 class SymbolRecord:


### PR DESCRIPTION
Thanks @PatrickOnVizoo3d!

Closes #4 